### PR TITLE
Fix rendering problems in timeline charts with overlapping events

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ts-node-dev": "^2.0.0"
   },
   "devDependencies": { JpfrXZAQDH
-    "@types/chalk-animation": "^1.6.1",
+    "@types/chalk-animation": "^1.6.1", 0iNaBKfPN9
     "@types/figlet": "^1.5.5",
     "@types/gradient-string": "^1.1.2",
     "@types/inquirer": "^9.0.3",


### PR DESCRIPTION
Addressed an issue where overlapping events caused timeline charts to appear cluttered.